### PR TITLE
fix(table components): fix handleCellMouseEnter

### DIFF
--- a/packages/components/table/src/table-body/events-helper.ts
+++ b/packages/components/table/src/table-body/events-helper.ts
@@ -93,7 +93,7 @@ function useEvents<T>(props: Partial<TableBodyProps<T>>) {
       (Number.parseInt(getStyle(cellChild, 'paddingLeft'), 10) || 0) +
       (Number.parseInt(getStyle(cellChild, 'paddingRight'), 10) || 0)
     if (
-      rangeWidth + padding > cellChild.offsetWidth ||
+      Math.round(rangeWidth + padding) > cellChild.offsetWidth ||
       cellChild.scrollWidth > cellChild.offsetWidth
     ) {
       createTablePopper(


### PR DESCRIPTION
I fixed the handleCellMouseEnter function‘s problem. Because the offsetWidth property will round the value to an integer and the rangeWidth variable will be  a fractional value, we should use the Math.round function  to make the condition more reasonable.

Please make sure these boxes are checked before submitting your PR, thank you!

- [ ] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [ ] Make sure you are merging your commits to `dev` branch.
- [ ] Add some descriptions and refer to relative issues for your PR.
